### PR TITLE
Fix group serialization, add a GenGraph virtual createGroup() method …

### DIFF
--- a/src/gtpoGraph.h
+++ b/src/gtpoGraph.h
@@ -596,7 +596,7 @@ public:
      *
      * \throw gtpo::bad_topology_error with an error description if insertion fails.
      */
-    virtual auto    createNode( const std::string& nodeClassName ) noexcept( false ) -> WeakNode;
+    virtual auto    createNode( const std::string& className ) noexcept( false ) -> WeakNode;
 
     /*! Insert a node created outside of GTpo into the graph.
      *
@@ -773,7 +773,16 @@ public:
      * \return the inserted group (if an error occurs a gtpo::bad_topology_error is thrown).
      * \throw a gtpo::bad_topology_error if insertion fails.
      */
-    auto        createGroup( const std::string& className = "" ) noexcept( false ) -> WeakGroup;
+    auto        createGroup( ) noexcept( false ) -> WeakGroup;
+
+    /*! \brief Used for serialization purposes, create a new group with a given class name \c className and insert it into the graph.
+     *
+     * Complexity is O(1).
+     * \arg className desired class name for the create node group (default to gtpo::Group).
+     * \return the inserted group (if an error occurs a gtpo::bad_topology_error is thrown).
+     * \throw a gtpo::bad_topology_error if insertion fails.
+     */
+    virtual auto    createGroup( const std::string& className ) noexcept( false ) -> WeakGroup;
 
     /*! Insert a node group into the graph.
      *

--- a/src/gtpoGraph.hpp
+++ b/src/gtpoGraph.hpp
@@ -72,11 +72,11 @@ auto GenGraph< Config >::createNode( ) -> WeakNode
 }
 
 template < class Config >
-auto    GenGraph< Config >::createNode( const std::string& nodeClassName ) noexcept( false ) -> WeakNode
+auto    GenGraph< Config >::createNode( const std::string& className ) noexcept( false ) -> WeakNode
 {
-    if ( nodeClassName == "gtpo::Node" )    // FIXME 20160212
+    if ( className == "gtpo::Node" )
         return createNode();
-    return WeakNode();
+    return WeakNode{};
 }
 
 template < class Config >
@@ -194,7 +194,7 @@ auto    GenGraph< Config >::createEdge( const std::string& className, WeakNode s
 {
     if ( className == "gtpo::Edge" )
         return createEdge( src, dst );
-    return WeakEdge();
+    return WeakEdge{};
 }
 
 template < class Config >
@@ -307,15 +307,22 @@ auto    GenGraph< Config >::getEdgeCount( WeakNode source, WeakNode destination 
 
 /* Graph Group Management *///-------------------------------------------------
 template < class Config >
-auto    GenGraph< Config >::createGroup( const std::string& className ) noexcept( false ) -> WeakGroup
+auto GenGraph< Config >::createGroup( ) -> WeakGroup
 {
-    (void)className;
     WeakGroup weakGroup;
     try {
         auto group = std::make_shared< typename Config::Group >();
         weakGroup = insertGroup( group );
     } catch (...) { gtpo::assert_throw( false, "gtpo::GenGraph<>::createGroup(): Error: can't insert group in graph." ); }
     return weakGroup;
+}
+
+template < class Config >
+auto    GenGraph< Config >::createGroup( const std::string& className ) noexcept( false ) -> WeakGroup
+{
+    if ( className == "gtpo::Group" )
+        return createGroup();
+    return WeakGroup{};
 }
 
 template < class Config >

--- a/src/gtpoGroup.hpp
+++ b/src/gtpoGroup.hpp
@@ -48,7 +48,6 @@ auto GenGroup< Config >::insertNode( WeakNode weakNode ) -> void
         this->notifyGroupModified( weakGroup );        // Notification
         this->notifyNodeInserted( weakNode );
         getGraph()->notifyGroupModified( weakGroup );
-
     } catch (...) { gtpo::assert_throw( false, "gtpo::GenGroup<>::insertNode(): Error: can't insert node in group." ); }
 }
 


### PR DESCRIPTION
…and implement dynamic group creation in Qan2.

Add methods gtpo::GenGraph<>::createGroup(), qan::Graph::createGroup().
Re-implement qan::Graph::removeGroup().
Fix GTPO serialization warning by taking non serializable node count into account during out serialization.
qan::Group::insertNode() overloaded version now insert the corresponding qan::Node in qan::Group.

Signed-off-by: cneben <benoit@qanava.org>